### PR TITLE
WIP: Fixing bug in fib test case

### DIFF
--- a/fib/test/test_fib.cc
+++ b/fib/test/test_fib.cc
@@ -48,5 +48,5 @@ TEST_CASE("Test") {
   // Try to get the result.
   int result = fib_recursive(9);
 
-  REQUIRE( result == fib_recursive(8) + 21);
+  REQUIRE( result == (fib_recursive(8) + 13));
 }


### PR DESCRIPTION
21 is the Fibonacci number at position 8, so adding 8th and 8th together is not correct. It should
have been 13.
